### PR TITLE
Layer groups/folders now can be saved back.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ TestResults
 ClientBin
 stylecop.*
 ~$*
+*.bak
 *.dbmdl
 Generated_Code #added for RIA/Silverlight projects
 

--- a/PhotoShopFileType/BitmapLayerInfo.cs
+++ b/PhotoShopFileType/BitmapLayerInfo.cs
@@ -1,0 +1,18 @@
+﻿using PaintDotNet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PaintDotNet.Data.PhotoshopFileType
+{
+    public class BitmapLayerInfo
+    {
+        public BitmapLayer Layer { get; set; }
+        public bool IsGroupStart { get; set; }
+        public bool IsGroupEnd { get; set; }
+        public bool RenderAsRegularLayer { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/PhotoShopFileType/PhotoShop.csproj
+++ b/PhotoShopFileType/PhotoShop.csproj
@@ -13,7 +13,7 @@
     <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>
     </AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -185,6 +185,7 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CustomToolNamespace>PaintDotNet.Data.PhotoshopFileType</CustomToolNamespace>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup />

--- a/PhotoShopFileType/PhotoShop.csproj
+++ b/PhotoShopFileType/PhotoShop.csproj
@@ -163,6 +163,7 @@
     <Compile Include="..\PsdFile\Util.cs">
       <Link>PsdFile\Util.cs</Link>
     </Compile>
+    <Compile Include="BitmapLayerInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="BlendModeMapping.cs" />
     <Compile Include="DocumentLoadContext.cs" />

--- a/PhotoShopFileType/PhotoshopFileType.cs
+++ b/PhotoShopFileType/PhotoshopFileType.cs
@@ -58,7 +58,7 @@ namespace PaintDotNet.Data.PhotoshopFileType
 
     protected override SaveConfigToken OnCreateDefaultSaveConfigToken()
     {
-      return new PsdSaveConfigToken(true);
+      return new PsdSaveConfigToken(true, false);
     }
 
     protected override void OnSave(Document input, System.IO.Stream output, SaveConfigToken token,

--- a/PhotoShopFileType/PsdLoad.cs
+++ b/PhotoShopFileType/PsdLoad.cs
@@ -147,8 +147,8 @@ namespace PaintDotNet.Data.PhotoshopFileType
       // will provide an alternative mechanism to retrieve the UI language.
 
       // Cache layer section strings
-      var beginSectionWrapper = PsdPluginResources.GetString("LayersPalette_LayerGroupBegin");
-      var endSectionWrapper = PsdPluginResources.GetString("LayersPalette_LayerGroupEnd");
+      var beginSectionWrapper = PsdPluginResources.GetString(PsdPluginResources.LayersPalette_LayerGroupBegin);
+      var endSectionWrapper = PsdPluginResources.GetString(PsdPluginResources.LayersPalette_LayerGroupEnd);
       
       // Track the depth of the topmost hidden section.  Any nested sections
       // will be hidden, whether or not they themselves have the flag set.
@@ -178,6 +178,8 @@ namespace PaintDotNet.Data.PhotoshopFileType
               topHiddenSectionDepth = layerSectionNames.Count;
             layerSectionNames.Push(layer.Name);
             layer.Name = String.Format(beginSectionWrapper, layer.Name);
+            // Store open or close state as visibility.
+            layer.Visible = sectionInfo.SectionType == LayerSectionType.OpenFolder;
             break;
 
           case LayerSectionType.SectionDivider:

--- a/PhotoShopFileType/PsdPluginResources.cs
+++ b/PhotoShopFileType/PsdPluginResources.cs
@@ -24,10 +24,44 @@ using PaintDotNet;
 
 namespace PaintDotNet.Data.PhotoshopFileType
 {
+  // TODO: It is not a correct way to store prefixed resources!
   public static class PsdPluginResources
   {
     private static ResourceManager rm =
       new ResourceManager("Photoshop.Resources", typeof(PsdPluginResources).Assembly);
+
+    public static string LayersPalette_LayerGroupBegin = "LayersPalette_LayerGroupBegin";
+    public static string LayersPalette_LayerGroupEnd = "LayersPalette_LayerGroupEnd";
+
+    /// <summary>
+    /// Get a collection of group name values for all languages.
+    /// </summary>
+    /// <returns></returns>
+    public static List<string> GetAllLayerGroupNames(string resourceKey)
+    {
+      var toReturn = new List<string>();
+      // While layer groups can be localized we should check all variations of localization.
+      var resources = rm.GetResourceSet(new System.Globalization.CultureInfo("en"), false, true);
+      if (resources != null)
+      {
+        foreach (System.Collections.DictionaryEntry entry in resources)
+        {
+          var key = entry.Key.ToString();
+          if (key == resourceKey || key.StartsWith(resourceKey) || key.EndsWith(resourceKey))
+          {
+            var value = entry.Value as string;
+            if (!string.IsNullOrEmpty(value) && value.Contains(':'))
+            {
+              var variantOfLocalizedLayer = value.Split(':')[0].Trim().ToLower();
+              if (!string.IsNullOrEmpty(variantOfLocalizedLayer))
+                toReturn.Add(variantOfLocalizedLayer);
+            }
+          }
+        }
+      }
+
+      return toReturn;
+    }
 
     public static string GetString(string resourceName)
     {
@@ -42,7 +76,7 @@ namespace PaintDotNet.Data.PhotoshopFileType
       // prefix the resource name with the language code.
       var taggedResourceName = languageCode + "_" + resourceName;
       var s = rm.GetString(taggedResourceName);
-      if (s != null)
+      if (!string.IsNullOrEmpty(s))
         return s;
 
       // If no translation is available, fall back to the untagged resource

--- a/PhotoShopFileType/PsdSaveConfigToken.cs
+++ b/PhotoShopFileType/PsdSaveConfigToken.cs
@@ -27,15 +27,18 @@ namespace PaintDotNet.Data.PhotoshopFileType
     }
 
     public bool RleCompress { get; set; }
+    public bool SaveLayers { get; set; }
 
-    public PsdSaveConfigToken(bool rleCompress)
+    public PsdSaveConfigToken(bool rleCompress, bool saveLayers)
     {
       this.RleCompress = rleCompress;
+      this.SaveLayers = saveLayers;
     }
 
     protected PsdSaveConfigToken(PsdSaveConfigToken copyMe)
     {
       this.RleCompress = copyMe.RleCompress;
+      this.SaveLayers = copyMe.SaveLayers;
     }
 
     public override void Validate()

--- a/PhotoShopFileType/PsdSaveConfigWidget.cs
+++ b/PhotoShopFileType/PsdSaveConfigWidget.cs
@@ -24,102 +24,141 @@ using PaintDotNet;
 
 namespace PaintDotNet.Data.PhotoshopFileType
 {
-  /// <summary>
-  /// Summary description for TgaSaveConfigWidget.
-  /// </summary>
-  public class PsdSaveConfigWidget 
-      : PaintDotNet.SaveConfigWidget
-  {
-    private System.Windows.Forms.CheckBox rleCompressCheckBox;
-
-    /// <summary> 
-    /// Required designer variable.
+    /// <summary>
+    /// Summary description for TgaSaveConfigWidget.
     /// </summary>
-    private System.ComponentModel.Container components = null;
-
-    public PsdSaveConfigWidget()
+    public class PsdSaveConfigWidget
+        : PaintDotNet.SaveConfigWidget
     {
-      // This call is required by the Windows.Forms Form Designer.
-      InitializeComponent();
+        private System.Windows.Forms.CheckBox rleCompressCheckBox;
+        private CheckBox cbLayers;
+        private Label label1;
+        private ToolTip toolTip1;
+        private IContainer components;
 
-      //this.bpp24Radio.Text = PdnResources.GetString("TgaSaveConfigWidget.Bpp24Radio.Text");
-      //this.bpp32Radio.Text = PdnResources.GetString("TgaSaveConfigWidget.Bpp32Radio.Text");
-      //this.bppLabel.Text = PdnResources.GetString("TgaSaveConfigWidget.BppLabel.Text");
-      //this.rleCompressCheckBox.Text = PdnResources.GetString("TgaSaveConfigWidget.RleCompressCheckBox.Text");
-    }
-
-    protected override void InitFileType()
-    {
-        this.fileType = new PhotoshopFileType();
-    }
-
-    protected override void InitTokenFromWidget()
-    {
-      ((PsdSaveConfigToken)this.token).RleCompress = this.rleCompressCheckBox.Checked;
-    }
-
-    protected override void InitWidgetFromToken(SaveConfigToken token)
-    {
-      if (token is PsdSaveConfigToken psdToken)
-      {
-        this.rleCompressCheckBox.Checked = psdToken.RleCompress;
-      }
-      else
-      {
-        this.rleCompressCheckBox.Checked = true;
-      }
-    }
-
-    /// <summary> 
-    /// Clean up any resources being used.
-    /// </summary>
-    protected override void Dispose(bool disposing)
-    {
-      if (disposing)
-      {
-        if (components != null)
+        public PsdSaveConfigWidget()
         {
-          components.Dispose();
+            // This call is required by the Windows.Forms Form Designer.
+            InitializeComponent();
+
+            //this.bpp24Radio.Text = PdnResources.GetString("TgaSaveConfigWidget.Bpp24Radio.Text");
+            //this.bpp32Radio.Text = PdnResources.GetString("TgaSaveConfigWidget.Bpp32Radio.Text");
+            //this.bppLabel.Text = PdnResources.GetString("TgaSaveConfigWidget.BppLabel.Text");
+            //this.rleCompressCheckBox.Text = PdnResources.GetString("TgaSaveConfigWidget.RleCompressCheckBox.Text");
         }
-      }
 
-      base.Dispose(disposing);
+        protected override void InitFileType()
+        {
+            this.fileType = new PhotoshopFileType();
+        }
+
+        protected override void InitTokenFromWidget()
+        {
+            var token = ((PsdSaveConfigToken)this.token);
+            token.RleCompress = this.rleCompressCheckBox.Checked;
+            token.SaveLayers = this.cbLayers.Checked;
+        }
+
+        protected override void InitWidgetFromToken(SaveConfigToken token)
+        {
+            if (token is PsdSaveConfigToken psdToken)
+            {
+                this.rleCompressCheckBox.Checked = psdToken.RleCompress;
+                this.cbLayers.Checked = psdToken.SaveLayers;
+            }
+            else
+            {
+                this.rleCompressCheckBox.Checked = true;
+                this.cbLayers.Checked = true;
+            }
+        }
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (components != null)
+                {
+                    components.Dispose();
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.rleCompressCheckBox = new System.Windows.Forms.CheckBox();
+            this.cbLayers = new System.Windows.Forms.CheckBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.SuspendLayout();
+            // 
+            // rleCompressCheckBox
+            // 
+            this.rleCompressCheckBox.Location = new System.Drawing.Point(0, 0);
+            this.rleCompressCheckBox.Name = "rleCompressCheckBox";
+            this.rleCompressCheckBox.Size = new System.Drawing.Size(184, 24);
+            this.rleCompressCheckBox.TabIndex = 0;
+            this.rleCompressCheckBox.Text = "RLE compression";
+            this.rleCompressCheckBox.CheckedChanged += new System.EventHandler(this.OnCheckedChanged);
+            // 
+            // cbLayers
+            // 
+            this.cbLayers.Location = new System.Drawing.Point(0, 28);
+            this.cbLayers.Name = "cbLayers";
+            this.cbLayers.Size = new System.Drawing.Size(184, 24);
+            this.cbLayers.TabIndex = 1;
+            this.cbLayers.Text = "Save Layers Groups";
+            this.toolTip1.SetToolTip(this.cbLayers, "Layers \"Layer Group:\" and \"End Layer Group:\" is about to be saved as a PSD group!" +
+              " Note: Your drawings on a layer group image might be lost!");
+            // 
+            // label1
+            // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(30, 55);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(0, 13);
+            this.label1.TabIndex = 2;
+            // 
+            // toolTip1
+            // 
+            this.toolTip1.AutomaticDelay = 100;
+            this.toolTip1.AutoPopDelay = 3000;
+            this.toolTip1.InitialDelay = 100;
+            this.toolTip1.ReshowDelay = 20;
+            this.toolTip1.ShowAlways = true;
+            this.toolTip1.UseAnimation = false;
+            // 
+            // PsdSaveConfigWidget
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.cbLayers);
+            this.Controls.Add(this.rleCompressCheckBox);
+            this.Name = "PsdSaveConfigWidget";
+            this.Size = new System.Drawing.Size(180, 104);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+        #endregion
+
+        private void OnCheckedChanged(object sender, System.EventArgs e)
+        {
+            this.UpdateToken();
+        }
     }
-
-    #region Component Designer generated code
-    /// <summary> 
-    /// Required method for Designer support - do not modify 
-    /// the contents of this method with the code editor.
-    /// </summary>
-    private void InitializeComponent()
-    {
-      this.rleCompressCheckBox = new System.Windows.Forms.CheckBox();
-      this.SuspendLayout();
-      // 
-      // rleCompressCheckBox
-      // 
-      this.rleCompressCheckBox.Location = new System.Drawing.Point(0, 0);
-      this.rleCompressCheckBox.Name = "rleCompressCheckBox";
-      this.rleCompressCheckBox.Size = new System.Drawing.Size(184, 24);
-      this.rleCompressCheckBox.TabIndex = 0;
-      this.rleCompressCheckBox.Text = PsdPluginResources.GetString("SaveDialog_RleCompression");
-      this.rleCompressCheckBox.CheckedChanged += new System.EventHandler(this.OnCheckedChanged);
-      // 
-      // PsdSaveConfigWidget
-      // 
-      this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-      this.Controls.Add(this.rleCompressCheckBox);
-      this.Name = "PsdSaveConfigWidget";
-      this.Size = new System.Drawing.Size(180, 104);
-      this.ResumeLayout(false);
-
-    }
-    #endregion
-
-    private void OnCheckedChanged(object sender, System.EventArgs e)
-    {
-        this.UpdateToken();
-    }
-  }
 }

--- a/PhotoShopFileType/PsdSaveConfigWidget.resx
+++ b/PhotoShopFileType/PsdSaveConfigWidget.resx
@@ -112,9 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/PsdFile/Layers/LayerInfo/LayerSectionInfo.cs
+++ b/PsdFile/Layers/LayerInfo/LayerSectionInfo.cs
@@ -62,6 +62,11 @@ namespace PhotoshopFile
         blendModeKey = value;
       }
     }
+        public LayerSectionInfo(LayerSectionType sectionType)
+        {
+            this.SectionType = sectionType;
+            this.key = "lsct";
+        }
 
     public LayerSectionInfo(PsdBinaryReader reader, string key, int dataLength)
     {


### PR DESCRIPTION
Issue: https://github.com/PsdPlugin/PsdPlugin/issues/6

Checkin: Layer groups/folder now can be saved back. While Paint.NET layers are flat all groups should be surrounded by "Layer Group:" and "End Layer Group:". Those layer boundaries are created by default when PSD is loaded. The tool will restore structure automatically if a user will mess up end and start layers.