### PR TITLE
Fix for DeflateStream.Read behavior change in .NET 6.0

### DIFF
--- a/PsdFile/Compression/ZipImage.cs
+++ b/PsdFile/Compression/ZipImage.cs
@@ -75,8 +75,15 @@ namespace PhotoshopFile.Compression
       var bytesToRead = (long)Size.Height * BytesPerRow;
       Util.CheckByteArrayLength(bytesToRead);
 
-      var bytesRead = zipStream.Read(buffer, 0, (int)bytesToRead);
-      if (bytesRead != bytesToRead)
+      var totalRead = 0;
+      while (totalRead < bytesToRead)
+      {
+        var bytesRead = zipStream.Read(buffer, totalRead, (int)bytesToRead - totalRead);
+        if(bytesRead == 0) { break; }
+        totalRead += bytesRead;
+      }
+      
+      if (totalRead != bytesToRead)
       {
         throw new Exception("ZIP stream was not fully decompressed.");
       }


### PR DESCRIPTION
Fixes: #16 

More info:
https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams